### PR TITLE
Add keepMessage option for queue processing

### DIFF
--- a/lib/queue.d.ts
+++ b/lib/queue.d.ts
@@ -8,6 +8,7 @@ export interface QueueOptions {
 }
 export interface ProcessOptions {
     oneShot?: boolean;
+    keepMessages?: boolean;
 }
 export declare class Queue<TItem> extends EventEmitter {
     private options;
@@ -15,6 +16,6 @@ export declare class Queue<TItem> extends EventEmitter {
     private stopped;
     constructor(options: QueueOptions);
     push(item: TItem): Promise<void>;
-    startProcessing(handler: (item: TItem) => any | PromiseLike<any>, options?: ProcessOptions): PromiseLike<void>;
+    startProcessing(handler: (item: TItem, message: SQS.Message) => any | PromiseLike<any>, options?: ProcessOptions): PromiseLike<void>;
     stopProcessing(): PromiseLike<void>;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqs-quooler",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "sqs-quooler",
   "license": "MIT",
   "repository": "",


### PR DESCRIPTION
This PR adds a flag to the `startProcessing` method to not delete the message after processing,
but instead, pass the message as an argument to the handler, so the handler can delete the message
whenever it wants.