### PR TITLE
Add `remove` from sqs method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqs-quooler",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "sqs-quooler",
   "license": "MIT",
   "repository": "",

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -32,6 +32,13 @@ export class Queue<TItem> extends EventEmitter {
     }).promise()
   }
 
+  async remove (message : SQS.Message) : Promise<void> {
+    await this.options.sqs.deleteMessage({
+      QueueUrl: this.options.endpoint,
+      ReceiptHandle: message.ReceiptHandle
+    }).promise()
+  }
+
   startProcessing (handler : (item : TItem, message : SQS.Message) => any | PromiseLike<any>, options?: ProcessOptions): PromiseLike<void> {
     let self = this
 


### PR DESCRIPTION
This PR adds a function to `remove` single messages from the queue.
This is specially useful when using the `keepMessages` (see #1)