### PR TITLE
queue: add error handling when polling items

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -51,7 +51,8 @@ class Queue extends events_1.EventEmitter {
                 .then(coerce)
                 .map(processItem)
                 .tap(delay)
-                .then(runAgain);
+                .then(runAgain)
+                .catch(handleCriticalError);
         }
         function processItem(message) {
             let body = JSON.parse(message.Body);
@@ -85,6 +86,10 @@ class Queue extends events_1.EventEmitter {
                 return;
             }
             return pollItems();
+        }
+        function handleCriticalError(err) {
+            self.emit('error', err);
+            return Bluebird.delay(100).then(pollItems);
         }
     }
     stopProcessing() {

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -72,7 +72,9 @@ export class Queue<TItem> extends EventEmitter {
         .map(processItem)
         .tap(delay)
         .then(runAgain)
+        .catch(handleCriticalError)
     }
+
 
     function processItem (message : SQS.Message) : PromiseLike<any> {
       let body = <TItem>JSON.parse(message.Body)
@@ -114,6 +116,12 @@ export class Queue<TItem> extends EventEmitter {
       }
 
       return pollItems()
+    }
+
+    function handleCriticalError (err : Error) {
+      self.emit('error', err)
+
+      return Bluebird.delay(100).then(pollItems)
     }
   }
 


### PR DESCRIPTION
Since `pollItems` function did not have a `.catch` at the end of the promise chain, we are adding it to avoid possible unhandled errors in the flow