### PR TITLE
chore: remove ts-lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
   "typings": "lib/index.d.ts",
   "scripts": {
     "clean": "rimraf lib",
-    "lint": "tslint --force --format verbose \"src/**/*.ts\"",
-    "build": "npm run clean && npm run lint && echo Using TypeScript && tsc --version && tsc --pretty",
+    "build": "npm run clean && echo Using TypeScript && tsc --version && tsc --pretty",
     "test": "npm run build && mocha --compilers ts:ts-node/register --recursive test/**/*-spec.ts",
     "watch": "npm run build -- --watch",
     "watch:test": "npm run test -- --watch"
@@ -36,7 +35,6 @@
     "mocha": "^3.0.1",
     "rimraf": "^2.5.4",
     "ts-node": "^1.2.2",
-    "tslint": "3.15.1",
     "typescript": "2.0.3"
   },
   "engines": {

--- a/tslint.json
+++ b/tslint.json
@@ -1,4 +1,0 @@
-{
-  "extends": "tslint:latest",
-  "semicolon": [true, "never"]
-}


### PR DESCRIPTION
Since this linter rules are not used across the project, this PR removes it.

Closes https://github.com/pagarme/ghostbusters/issues/251.