### PR TITLE
queue: support string as body message

### DIFF
--- a/src/queue.js
+++ b/src/queue.js
@@ -41,7 +41,12 @@ export default class Queue extends EventEmitter {
     self.running = true
 
     const processItem = (message) => {
-      const body = JSON.parse(message.Body)
+      let body = ''
+      try {
+        body = JSON.parse(message.Body)
+      } catch (e) {
+        body = message.Body
+      }
 
       const deleteMessage = () => {
         if (options.keepMessages) {


### PR DESCRIPTION
The method startProcessing now accepts MessageBody as being String.
Eg: Uncaught SyntaxError: Unexpected token a in JSON at position 0

This closes: [#301](https://github.com/pagarme/ghostbusters/issues/301)

Co-authored-by: otaviopace <otavio.pace@pagar.me>


![ghostbusting](https://media.giphy.com/media/Vse57fdw0kkLK/giphy.gif)
