### PR TITLE
version: v1.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqs-quooler",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "An abstraction of AWS SQS",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
# Version bump

Bump version to v1.5.1

## Changelog
 - `startProcessing` now supports other types besides JSON [#13](https://github.com/pagarme/sqs-quooler/pull/13)