### PR TITLE
Adding priority queues class

### DIFF
--- a/lib/custom-error.js
+++ b/lib/custom-error.js
@@ -1,0 +1,33 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var CustomError = function (_Error) {
+  _inherits(CustomError, _Error);
+
+  function CustomError() {
+    var _ref = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {},
+        message = _ref.message,
+        type = _ref.type;
+
+    _classCallCheck(this, CustomError);
+
+    var _this = _possibleConstructorReturn(this, (CustomError.__proto__ || Object.getPrototypeOf(CustomError)).call(this));
+
+    _this.type = type;
+    _this.message = message;
+    return _this;
+  }
+
+  return CustomError;
+}(Error);
+
+exports.default = CustomError;

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.Queue = undefined;
+exports.PrioritiesQueues = exports.Queue = undefined;
 
 require('babel-polyfill');
 
@@ -11,7 +11,12 @@ var _queue = require('./queue');
 
 var _queue2 = _interopRequireDefault(_queue);
 
+var _prioritiesQueues = require('./priorities-queues');
+
+var _prioritiesQueues2 = _interopRequireDefault(_prioritiesQueues);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 // eslint-disable-next-line import/prefer-default-export
 exports.Queue = _queue2.default;
+exports.PrioritiesQueues = _prioritiesQueues2.default;

--- a/lib/priorities-queues.js
+++ b/lib/priorities-queues.js
@@ -1,0 +1,411 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _slicedToArray = function () { function sliceIterator(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"]) _i["return"](); } finally { if (_d) throw _e; } } return _arr; } return function (arr, i) { if (Array.isArray(arr)) { return arr; } else if (Symbol.iterator in Object(arr)) { return sliceIterator(arr, i); } else { throw new TypeError("Invalid attempt to destructure non-iterable instance"); } }; }();
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _bluebird = require('bluebird');
+
+var _bluebird2 = _interopRequireDefault(_bluebird);
+
+var _events = require('events');
+
+var _customError = require('./custom-error');
+
+var _customError2 = _interopRequireDefault(_customError);
+
+var _signal = require('./signal');
+
+var _signal2 = _interopRequireDefault(_signal);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _asyncToGenerator(fn) { return function () { var gen = fn.apply(this, arguments); return new Promise(function (resolve, reject) { function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { return Promise.resolve(value).then(function (value) { step("next", value); }, function (err) { step("throw", err); }); } } return step("next"); }); }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var PrioritiesQueues = function (_EventEmitter) {
+  _inherits(PrioritiesQueues, _EventEmitter);
+
+  function PrioritiesQueues(options) {
+    _classCallCheck(this, PrioritiesQueues);
+
+    var _this = _possibleConstructorReturn(this, (PrioritiesQueues.__proto__ || Object.getPrototypeOf(PrioritiesQueues)).call(this));
+
+    if (!options) {
+      throw new _customError2.default({
+        type: 'missing parameter',
+        message: 'This method requires an options as the first argument'
+      });
+    }
+
+    if (!options.sqs) {
+      throw new _customError2.default({
+        type: 'missing parameter',
+        message: 'This method requires options.sqs'
+      });
+    }
+
+    if (!options.queues || !Object.keys(options.queues).length) {
+      throw new _customError2.default({
+        type: 'missing parameter',
+        message: 'This method requires options.queues'
+      });
+    }
+
+    if (!options.priorities || !options.priorities.length) {
+      throw new _customError2.default({
+        type: 'missing parameter',
+        message: 'This method requires options.priorities'
+      });
+    }
+
+    options.priorities.forEach(function (queueName) {
+      if (!options.queues[queueName]) {
+        throw new _customError2.default({
+          type: 'invalid parameter',
+          message: 'There are queues at priorities list that are not at the queues list'
+        });
+      }
+    });
+
+    _this.options = options;
+    _this.customPriorities = [].concat(options.priorities);
+    _this.prioritiesCount = options.priorities.reduce(function (result, priority) {
+      // eslint-disable-next-line no-param-reassign
+      result[priority] = 0;
+      return result;
+    }, {});
+
+    _this.maxPriorityRetries = options.maxPriorityRetries || 5;
+    return _this;
+  }
+
+  _createClass(PrioritiesQueues, [{
+    key: 'push',
+    value: function () {
+      var _ref = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee(item, queue) {
+        var parameters = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
+        return regeneratorRuntime.wrap(function _callee$(_context) {
+          while (1) {
+            switch (_context.prev = _context.next) {
+              case 0:
+                if (queue) {
+                  _context.next = 2;
+                  break;
+                }
+
+                throw new _customError2.default({
+                  type: 'missing parameter',
+                  message: 'This method requires a queue name as the second argument'
+                });
+
+              case 2:
+                if (this.options.queues[queue]) {
+                  _context.next = 4;
+                  break;
+                }
+
+                throw new _customError2.default({
+                  type: 'invalid parameter',
+                  message: 'Invalid queue name provided, please select a valid queue'
+                });
+
+              case 4:
+                return _context.abrupt('return', this.options.sqs.sendMessage(Object.assign({}, {
+                  QueueUrl: this.options.queues[queue],
+                  MessageBody: JSON.stringify(item)
+                }, parameters)).promise());
+
+              case 5:
+              case 'end':
+                return _context.stop();
+            }
+          }
+        }, _callee, this);
+      }));
+
+      function push(_x2, _x3) {
+        return _ref.apply(this, arguments);
+      }
+
+      return push;
+    }()
+  }, {
+    key: 'remove',
+    value: function () {
+      var _ref2 = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee2(message, queue) {
+        return regeneratorRuntime.wrap(function _callee2$(_context2) {
+          while (1) {
+            switch (_context2.prev = _context2.next) {
+              case 0:
+                if (message) {
+                  _context2.next = 2;
+                  break;
+                }
+
+                throw new _customError2.default({
+                  type: 'missing parameter',
+                  message: 'This method requires a message as the first argument'
+                });
+
+              case 2:
+                if (queue) {
+                  _context2.next = 4;
+                  break;
+                }
+
+                throw new _customError2.default({
+                  type: 'missing parameter',
+                  message: 'This method requires a queue name as the second argument'
+                });
+
+              case 4:
+                if (message.ReceiptHandle) {
+                  _context2.next = 6;
+                  break;
+                }
+
+                throw new _customError2.default({
+                  type: 'invalid parameter',
+                  message: 'Invalid message provided, the message must include ReceiptHandle attribute'
+                });
+
+              case 6:
+                if (this.options.queues[queue]) {
+                  _context2.next = 8;
+                  break;
+                }
+
+                throw new _customError2.default({
+                  type: 'invalid parameter',
+                  message: 'Invalid queue name provided, please select a valid queue'
+                });
+
+              case 8:
+                return _context2.abrupt('return', this.options.sqs.deleteMessage({
+                  QueueUrl: this.options.queues[queue],
+                  ReceiptHandle: message.ReceiptHandle
+                }).promise());
+
+              case 9:
+              case 'end':
+                return _context2.stop();
+            }
+          }
+        }, _callee2, this);
+      }));
+
+      function remove(_x4, _x5) {
+        return _ref2.apply(this, arguments);
+      }
+
+      return remove;
+    }()
+  }, {
+    key: 'changeMessageVisibility',
+    value: function () {
+      var _ref3 = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee3() {
+        var parameters = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+        var queue = arguments[1];
+        return regeneratorRuntime.wrap(function _callee3$(_context3) {
+          while (1) {
+            switch (_context3.prev = _context3.next) {
+              case 0:
+                if (parameters) {
+                  _context3.next = 2;
+                  break;
+                }
+
+                throw new _customError2.default({
+                  type: 'missing parameter',
+                  message: 'This method requires a parameters object as the first argument'
+                });
+
+              case 2:
+                if (queue) {
+                  _context3.next = 4;
+                  break;
+                }
+
+                throw new _customError2.default({
+                  type: 'missing parameter',
+                  message: 'This method requires a queue name as the second argument'
+                });
+
+              case 4:
+                if (this.options.queues[queue]) {
+                  _context3.next = 6;
+                  break;
+                }
+
+                throw new _customError2.default({
+                  type: 'invalid parameter',
+                  message: 'Invalid queue name provided, please select a valid queue'
+                });
+
+              case 6:
+                return _context3.abrupt('return', this.options.sqs.changeMessageVisibility(Object.assign({}, {
+                  QueueUrl: this.options.queues[queue]
+                }, parameters)).promise());
+
+              case 7:
+              case 'end':
+                return _context3.stop();
+            }
+          }
+        }, _callee3, this);
+      }));
+
+      function changeMessageVisibility() {
+        return _ref3.apply(this, arguments);
+      }
+
+      return changeMessageVisibility;
+    }()
+  }, {
+    key: 'startProcessing',
+    value: function startProcessing(handler) {
+      var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+
+      var self = this;
+
+      self.running = true;
+
+      var processItem = function processItem(message) {
+        var body = '';
+        try {
+          body = JSON.parse(message.Body);
+        } catch (e) {
+          body = message.Body;
+        }
+
+        var deleteMessage = function deleteMessage() {
+          if (options.keepMessages) {
+            return _bluebird2.default.resolve();
+          }
+
+          return self.remove(message, message.queue);
+        };
+
+        var handleError = function handleError(err) {
+          self.emit('error', err);
+        };
+
+        return _bluebird2.default.resolve([body, message]).spread(handler).then(deleteMessage).catch(handleError);
+      };
+
+      var coerce = function coerce(x) {
+        return x || [];
+      };
+
+      var delay = function delay(items) {
+        if (items.length === 0) {
+          return _bluebird2.default.delay(100);
+        }
+
+        return _bluebird2.default.resolve();
+      };
+
+      var pollItems = function pollItems() {
+        if (!self.running) {
+          self.stopped.trigger();
+
+          return Promise.resolve();
+        }
+
+        var runAgain = function runAgain() {
+          if (options.oneShot) {
+            return _bluebird2.default.resolve();
+          }
+
+          self.customPriorities = [].concat(self.options.priorities);
+
+          return pollItems();
+        };
+
+        var handleCriticalError = function handleCriticalError(err) {
+          self.emit('error', err);
+
+          return _bluebird2.default.delay(100).then(pollItems);
+        };
+
+        var getMessages = function getMessages() {
+          var priorityIndex = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 0;
+
+          var queue = self.customPriorities[priorityIndex];
+
+          if (!queue) {
+            return [];
+          }
+
+          return _bluebird2.default.resolve().then(function () {
+            return self.options.sqs.receiveMessage({
+              QueueUrl: self.options.queues[queue],
+              MaxNumberOfMessages: self.options.concurrency
+            }).promise();
+          }).get('Messages').then(coerce).then(function (itens) {
+            if (itens.length) {
+              return itens.map(function (item) {
+                return Object.assign({}, item, { queue: queue });
+              });
+            }
+
+            return getMessages(priorityIndex + 1);
+          });
+        };
+
+        function checkPriorities() {
+          var firstCustomPriority = self.customPriorities[0];
+
+          if (self.prioritiesCount[firstCustomPriority] >= self.maxPriorityRetries) {
+            self.customPriorities = self.customPriorities.concat(self.customPriorities.shift());
+            self.prioritiesCount[firstCustomPriority] = 0;
+          }
+
+          var _self$customPrioritie = _slicedToArray(self.customPriorities, 1);
+
+          firstCustomPriority = _self$customPrioritie[0];
+
+
+          if (self.prioritiesCount[firstCustomPriority] >= self.maxPriorityRetries) {
+            checkPriorities();
+          }
+        }
+
+        checkPriorities();
+
+        var firstCustomPriority = self.customPriorities[0];
+        self.prioritiesCount[firstCustomPriority] += 1;
+
+        return getMessages().map(processItem).tap(delay).then(runAgain).catch(handleCriticalError);
+      };
+
+      return pollItems();
+    }
+  }, {
+    key: 'stopProcessing',
+    value: function stopProcessing() {
+      if (!this.running) {
+        return this.stopped.promise;
+      }
+
+      this.running = false;
+      this.stopped = new _signal2.default();
+
+      return this.stopped.promise;
+    }
+  }]);
+
+  return PrioritiesQueues;
+}(_events.EventEmitter);
+
+exports.default = PrioritiesQueues;

--- a/lib/queues.js
+++ b/lib/queues.js
@@ -26,19 +26,19 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-var Queue = function (_EventEmitter) {
-  _inherits(Queue, _EventEmitter);
+var Queues = function (_EventEmitter) {
+  _inherits(Queues, _EventEmitter);
 
-  function Queue(options) {
-    _classCallCheck(this, Queue);
+  function Queues(options) {
+    _classCallCheck(this, Queues);
 
-    var _this = _possibleConstructorReturn(this, (Queue.__proto__ || Object.getPrototypeOf(Queue)).call(this));
+    var _this = _possibleConstructorReturn(this, (Queues.__proto__ || Object.getPrototypeOf(Queues)).call(this));
 
     _this.options = options;
     return _this;
   }
 
-  _createClass(Queue, [{
+  _createClass(Queues, [{
     key: 'push',
     value: function () {
       var _ref = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee(item) {
@@ -213,7 +213,7 @@ var Queue = function (_EventEmitter) {
     }
   }]);
 
-  return Queue;
+  return Queues;
 }(_events.EventEmitter);
 
-exports.default = Queue;
+exports.default = Queues;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqs-quooler",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "description": "An abstraction of AWS SQS",
   "license": "MIT",
   "repository": {

--- a/src/custom-error.js
+++ b/src/custom-error.js
@@ -1,0 +1,10 @@
+class CustomError extends Error {
+  constructor ({ message, type } = {}) {
+    super()
+
+    this.type = type
+    this.message = message
+  }
+}
+
+export default CustomError

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,8 @@
 import 'babel-polyfill'
 import Queue from './queue'
+import PrioritiesQueues from './priorities-queues'
 
-// eslint-disable-next-line import/prefer-default-export
-export { Queue }
+export {
+  Queue,
+  PrioritiesQueues,
+}

--- a/src/priorities-queues.js
+++ b/src/priorities-queues.js
@@ -1,0 +1,284 @@
+import Bluebird from 'bluebird'
+import { EventEmitter } from 'events'
+import CustomError from './custom-error'
+import Signal from './signal'
+
+export default class PrioritiesQueues extends EventEmitter {
+  constructor (options) {
+    super()
+
+    if (!options) {
+      throw new CustomError({
+        type: 'missing parameter',
+        message: 'This method requires an options as the first argument',
+      })
+    }
+
+    if (!options.sqs) {
+      throw new CustomError({
+        type: 'missing parameter',
+        message: 'This method requires options.sqs',
+      })
+    }
+
+    if (!options.queues || !Object.keys(options.queues).length) {
+      throw new CustomError({
+        type: 'missing parameter',
+        message: 'This method requires options.queues',
+      })
+    }
+
+    if (!options.priorities || !options.priorities.length) {
+      throw new CustomError({
+        type: 'missing parameter',
+        message: 'This method requires options.priorities',
+      })
+    }
+
+    options.priorities.forEach((queueName) => {
+      if (!options.queues[queueName]) {
+        throw new CustomError({
+          type: 'invalid parameter',
+          message: 'There are queues at priorities list that are not at the queues list',
+        })
+      }
+    })
+
+    this.options = options
+    this.customPriorities = [].concat(options.priorities)
+    this.prioritiesCount = options.priorities
+      .reduce((result, priority) => {
+        // eslint-disable-next-line no-param-reassign
+        result[priority] = 0
+        return result
+      }, {})
+
+    this.maxPriorityRetries = options.maxPriorityRetries
+  }
+
+  async push (item, queue, parameters = {}) {
+    if (!queue) {
+      throw new CustomError({
+        type: 'missing parameter',
+        message: 'This method requires a queue name as the second argument',
+      })
+    }
+
+    if (!this.options.queues[queue]) {
+      throw new CustomError({
+        type: 'invalid parameter',
+        message: 'Invalid queue name provided, please select a valid queue',
+      })
+    }
+
+    return this.options.sqs
+      .sendMessage(Object.assign({}, {
+        QueueUrl: this.options.queues[queue],
+        MessageBody: JSON.stringify(item),
+      }, parameters))
+      .promise()
+  }
+
+  async remove (message, queue) {
+    if (!message) {
+      throw new CustomError({
+        type: 'missing parameter',
+        message: 'This method requires a message as the first argument',
+      })
+    }
+
+    if (!queue) {
+      throw new CustomError({
+        type: 'missing parameter',
+        message: 'This method requires a queue name as the second argument',
+      })
+    }
+
+    if (!message.ReceiptHandle) {
+      throw new CustomError({
+        type: 'invalid parameter',
+        message: 'Invalid message provided, the message must include ReceiptHandle attribute',
+      })
+    }
+
+    if (!this.options.queues[queue]) {
+      throw new CustomError({
+        type: 'invalid parameter',
+        message: 'Invalid queue name provided, please select a valid queue',
+      })
+    }
+
+    return this.options.sqs
+      .deleteMessage({
+        QueueUrl: this.options.queues[queue],
+        ReceiptHandle: message.ReceiptHandle,
+      })
+      .promise()
+  }
+
+  async changeMessageVisibility (parameters = {}, queue) {
+    if (!parameters) {
+      throw new CustomError({
+        type: 'missing parameter',
+        message: 'This method requires a parameters object as the first argument',
+      })
+    }
+
+    if (!queue) {
+      throw new CustomError({
+        type: 'missing parameter',
+        message: 'This method requires a queue name as the second argument',
+      })
+    }
+
+    if (!this.options.queues[queue]) {
+      throw new CustomError({
+        type: 'invalid parameter',
+        message: 'Invalid queue name provided, please select a valid queue',
+      })
+    }
+
+    return this.options.sqs
+      .changeMessageVisibility(Object.assign({}, {
+        QueueUrl: this.options.queues[queue],
+      }, parameters))
+      .promise()
+  }
+
+  startProcessing (handler, options = {}) {
+    const self = this
+
+    self.running = true
+
+    const processItem = (message) => {
+      let body = ''
+      try {
+        body = JSON.parse(message.Body)
+      } catch (e) {
+        body = message.Body
+      }
+
+      const deleteMessage = () => {
+        if (options.keepMessages) {
+          return Bluebird.resolve()
+        }
+
+        return self.remove(message, message.queue)
+      }
+
+      const handleError = (err) => {
+        self.emit('error', err)
+      }
+
+      return Bluebird.resolve([body, message])
+        .spread(handler)
+        .then(deleteMessage)
+        .catch(handleError)
+    }
+
+    const coerce = x => x || []
+
+    const delay = (items) => {
+      if (items.length === 0) {
+        return Bluebird.delay(100)
+      }
+
+      return Bluebird.resolve()
+    }
+
+    const pollItems = () => {
+      if (!self.running) {
+        self.stopped.trigger()
+
+        return Promise.resolve()
+      }
+
+      const runAgain = () => {
+        if (options.oneShot) {
+          return Bluebird.resolve()
+        }
+
+        self.customPriorities = [].concat(self.options.priorities)
+
+        return pollItems()
+      }
+
+      const handleCriticalError = (err) => {
+        self.emit('error', err)
+
+        return Bluebird.delay(100).then(pollItems)
+      }
+
+      const getMessages = (priorityIndex = 0) => {
+        const queue = self.customPriorities[priorityIndex]
+
+        if (!queue) {
+          return []
+        }
+
+        return Bluebird.resolve()
+          .then(() => self.options.sqs
+            .receiveMessage({
+              QueueUrl: self.options.queues[queue],
+              MaxNumberOfMessages: self.options.concurrency,
+            })
+            .promise())
+          .get('Messages')
+          .then(coerce)
+          .then((itens) => {
+            if (itens.length) {
+              return itens.map(item => Object.assign({}, item, { queue }))
+            }
+
+            return getMessages(priorityIndex + 1)
+          })
+      }
+
+      function checkPriorities () {
+        let firstCustomPriority = self.customPriorities[0]
+
+        if (
+          self.prioritiesCount[firstCustomPriority] >= self.maxPriorityRetries
+        ) {
+          self.customPriorities = self.customPriorities
+            .concat(self.customPriorities.shift())
+          self.prioritiesCount[firstCustomPriority] = 0
+        }
+
+        [firstCustomPriority] = self.customPriorities
+
+        if (
+          self.prioritiesCount[firstCustomPriority] >= self.maxPriorityRetries
+        ) {
+          checkPriorities()
+        }
+      }
+
+      if (self.maxPriorityRetries) {
+        checkPriorities()
+      }
+
+      const firstCustomPriority = self.customPriorities[0]
+      self.prioritiesCount[firstCustomPriority] += 1
+
+      return getMessages()
+        .map(processItem)
+        .tap(delay)
+        .then(runAgain)
+        .catch(handleCriticalError)
+    }
+
+    return pollItems()
+  }
+
+  stopProcessing () {
+    if (!this.running) {
+      return this.stopped.promise
+    }
+
+    this.running = false
+    this.stopped = new Signal()
+
+    return this.stopped.promise
+  }
+}

--- a/test/priorities-queue-spec.js
+++ b/test/priorities-queue-spec.js
@@ -1,0 +1,632 @@
+import * as chai from 'chai'
+import { Credentials, SQS } from 'aws-sdk'
+import PrioritiesQueues from '../src/priorities-queues'
+
+const { expect } = chai
+
+const yopaEndpoint = 'http://yopa:47195/queue'
+const lowPirority = 'low-priority'
+const defaultPirority = 'default-priority'
+const highPirority = 'high-priority'
+
+describe('PrioritiesQueues', () => {
+  let sqs
+  let myQueues
+
+
+  before(async () => {
+    sqs = await new SQS({
+      region: 'yopa-local',
+      credentials: new Credentials({
+        accessKeyId: 'x',
+        secretAccessKey: 'x',
+      }),
+    })
+  })
+
+  beforeEach(async () => {
+    await sqs.purgeQueue({
+      QueueUrl: `${yopaEndpoint}/${lowPirority}`,
+    }).promise()
+
+    await sqs.purgeQueue({
+      QueueUrl: `${yopaEndpoint}/${defaultPirority}`,
+    }).promise()
+
+    await sqs.purgeQueue({
+      QueueUrl: `${yopaEndpoint}/${highPirority}`,
+    }).promise()
+  })
+
+  describe('when creating a priorities queue instance', () => {
+    describe('with correct parameters', () => {
+      before(() => {
+        myQueues = new PrioritiesQueues({
+          sqs,
+          queues: {
+            [lowPirority]: `${yopaEndpoint}/${lowPirority}`,
+            [defaultPirority]: `${yopaEndpoint}/${defaultPirority}`,
+            [highPirority]: `${yopaEndpoint}/${highPirority}`,
+          },
+          priorities: [
+            highPirority,
+            defaultPirority,
+            lowPirority,
+          ],
+        })
+      })
+
+      it('should have a successful instance', () => {
+        expect(myQueues).to.be.instanceOf(PrioritiesQueues)
+        expect(myQueues).to.have.property('options')
+      })
+    })
+
+    describe('without queues', () => {
+      let error
+
+      before(() => {
+        try {
+          myQueues = new PrioritiesQueues({
+            sqs,
+            priorities: [
+              highPirority,
+              defaultPirority,
+              lowPirority,
+            ],
+          })
+        } catch (err) {
+          error = err
+        }
+      })
+
+      it('should have a successful instance', () => {
+        expect(error).to.be.instanceOf(Error)
+        expect(error).to.have.property('type', 'missing parameter')
+      })
+    })
+
+    describe('without priorities', () => {
+      let error
+
+      before(() => {
+        try {
+          myQueues = new PrioritiesQueues({
+            sqs,
+            queues: {
+              [lowPirority]: `${yopaEndpoint}/${lowPirority}`,
+              [defaultPirority]: `${yopaEndpoint}/${defaultPirority}`,
+              [highPirority]: `${yopaEndpoint}/${highPirority}`,
+            },
+          })
+        } catch (err) {
+          error = err
+        }
+      })
+
+      it('should have a successful instance', () => {
+        expect(error).to.be.instanceOf(Error)
+        expect(error).to.have.property('type', 'missing parameter')
+      })
+    })
+
+    describe('with invalid priority', () => {
+      let error
+
+      before(() => {
+        try {
+          myQueues = new PrioritiesQueues({
+            sqs,
+            queues: {
+              [lowPirority]: `${yopaEndpoint}/${lowPirority}`,
+              [defaultPirority]: `${yopaEndpoint}/${defaultPirority}`,
+              [highPirority]: `${yopaEndpoint}/${highPirority}`,
+            },
+            priorities: [
+              'fake-queue-name',
+              defaultPirority,
+              lowPirority,
+            ],
+          })
+        } catch (err) {
+          error = err
+        }
+      })
+
+      it('should have a successful instance', () => {
+        expect(error).to.be.instanceOf(Error)
+        expect(error).to.have.property('type', 'invalid parameter')
+      })
+    })
+
+    describe('with maxPriorityRetries', () => {
+      before(() => {
+        myQueues = new PrioritiesQueues({
+          sqs,
+          queues: {
+            [lowPirority]: `${yopaEndpoint}/${lowPirority}`,
+            [defaultPirority]: `${yopaEndpoint}/${defaultPirority}`,
+            [highPirority]: `${yopaEndpoint}/${highPirority}`,
+          },
+          priorities: [
+            highPirority,
+            defaultPirority,
+            lowPirority,
+          ],
+          maxPriorityRetries: 50,
+        })
+      })
+
+      it('should have an instance with maxPriorityRetries as 50', () => {
+        expect(myQueues).to.have.property('maxPriorityRetries', 50)
+      })
+    })
+  })
+
+  describe('when pushing items', () => {
+    before(async () => {
+      myQueues = new PrioritiesQueues({
+        sqs,
+        queues: {
+          [lowPirority]: `${yopaEndpoint}/${lowPirority}`,
+          [defaultPirority]: `${yopaEndpoint}/${defaultPirority}`,
+          [highPirority]: `${yopaEndpoint}/${highPirority}`,
+        },
+        priorities: [
+          highPirority,
+          defaultPirority,
+          lowPirority,
+        ],
+        concurrency: 1,
+      })
+    })
+
+    describe('passing a correct queue name', () => {
+      let result
+
+      before(async () => {
+        result = await myQueues.push('high', highPirority)
+      })
+
+      it('should have a valid response', () => {
+        expect(typeof result).to.be.equal('object')
+        expect(result).to.have.property('MessageId')
+        expect(result).to.have.property('ResponseMetadata')
+      })
+    })
+    describe('passing an invalid queue name', () => {
+      let error
+
+      before(async () => {
+        try {
+          await myQueues.push('high', 'invalid-queue-name')
+        } catch (err) {
+          error = err
+        }
+      })
+
+      it('should have an error as response', () => {
+        expect(error).to.be.instanceOf(Error)
+        expect(error).to.have.property('type', 'invalid parameter')
+        expect(error).to.have.property('message')
+      })
+    })
+    describe('without any queue name', () => {
+      let error
+
+      before(async () => {
+        try {
+          await myQueues.push('high')
+        } catch (err) {
+          error = err
+        }
+      })
+
+      it('should have an error as response', () => {
+        expect(error).to.be.instanceOf(Error)
+        expect(error).to.have.property('type', 'missing parameter')
+        expect(error).to.have.property('message')
+      })
+    })
+  })
+
+  describe('when removing items', () => {
+    before(async () => {
+      myQueues = new PrioritiesQueues({
+        sqs,
+        queues: {
+          [lowPirority]: `${yopaEndpoint}/${lowPirority}`,
+          [defaultPirority]: `${yopaEndpoint}/${defaultPirority}`,
+          [highPirority]: `${yopaEndpoint}/${highPirority}`,
+        },
+        priorities: [
+          highPirority,
+          defaultPirority,
+          lowPirority,
+        ],
+        concurrency: 1,
+      })
+    })
+
+    describe('passing correct parameters', () => {
+      let message
+      let result
+
+      before(async () => {
+        await myQueues.push('high', highPirority)
+
+        await myQueues.startProcessing(
+          (_, messageData) => {
+            message = messageData
+          },
+          {
+            oneShot: true,
+          }
+        )
+
+        result = await myQueues.remove(message, highPirority)
+      })
+
+      it('should have a valid response', () => {
+        expect(typeof result).to.be.equal('object')
+        expect(result).to.have.property('ResponseMetadata')
+      })
+    })
+
+    describe('without message', () => {
+      let error
+
+      before(async () => {
+        try {
+          await myQueues.remove()
+        } catch (err) {
+          error = err
+        }
+      })
+
+      it('should have a valid response', () => {
+        expect(error).to.be.instanceOf(Error)
+        expect(error).to.have.property('type', 'missing parameter')
+      })
+    })
+
+    describe('without queue name', () => {
+      let error
+
+      before(async () => {
+        try {
+          await myQueues.remove({ ReceiptHandle: 'fake-id' })
+        } catch (err) {
+          error = err
+        }
+      })
+
+      it('should have a valid response', () => {
+        expect(error).to.be.instanceOf(Error)
+        expect(error).to.have.property('type', 'missing parameter')
+      })
+    })
+
+    describe('with invalid message', () => {
+      let error
+
+      before(async () => {
+        try {
+          await myQueues.remove({}, 'invalid-queue-name')
+        } catch (err) {
+          error = err
+        }
+      })
+
+      it('should have a valid response', () => {
+        expect(error).to.be.instanceOf(Error)
+        expect(error).to.have.property('type', 'invalid parameter')
+      })
+    })
+
+    describe('with invalid queue name', () => {
+      let error
+
+      before(async () => {
+        try {
+          await myQueues.remove({ ReceiptHandle: 'fake-id' }, 'invalid-queue-name')
+        } catch (err) {
+          error = err
+        }
+      })
+
+      it('should have a valid response', () => {
+        expect(error).to.be.instanceOf(Error)
+        expect(error).to.have.property('type', 'invalid parameter')
+      })
+    })
+  })
+
+  describe('when processing items', () => {
+    describe('when processing an item from highest priority queue', () => {
+      let foundItem
+      let foundQueue
+
+      before(async () => {
+        myQueues = new PrioritiesQueues({
+          sqs,
+          queues: {
+            [lowPirority]: `${yopaEndpoint}/${lowPirority}`,
+            [defaultPirority]: `${yopaEndpoint}/${defaultPirority}`,
+            [highPirority]: `${yopaEndpoint}/${highPirority}`,
+          },
+          priorities: [
+            highPirority,
+            defaultPirority,
+            lowPirority,
+          ],
+          concurrency: 1,
+        })
+
+        await myQueues.push('high', highPirority)
+      })
+
+      before(async () => {
+        await myQueues.startProcessing(
+          (body, { queue }) => {
+            foundItem = body
+            foundQueue = queue
+          },
+          {
+            oneShot: true,
+          }
+        )
+      })
+
+      it('should have an item processed from the high priority queue', () => {
+        expect(foundItem).to.be.equal('high')
+        expect(foundQueue).to.be.equal(highPirority)
+      })
+    })
+
+    describe('when processing an item from default priority queue', () => {
+      let foundItem
+      let foundQueue
+
+      before(async () => {
+        myQueues = new PrioritiesQueues({
+          sqs,
+          queues: {
+            [lowPirority]: `${yopaEndpoint}/${lowPirority}`,
+            [defaultPirority]: `${yopaEndpoint}/${defaultPirority}`,
+            [highPirority]: `${yopaEndpoint}/${highPirority}`,
+          },
+          priorities: [
+            highPirority,
+            defaultPirority,
+            lowPirority,
+          ],
+          concurrency: 1,
+        })
+
+        await myQueues.push('default', defaultPirority)
+      })
+
+      before(async () => {
+        await myQueues.startProcessing(
+          (body, { queue }) => {
+            foundItem = body
+            foundQueue = queue
+          },
+          {
+            oneShot: true,
+          }
+        )
+      })
+
+      it('should have an item processed from the default priority queue', () => {
+        expect(foundItem).to.be.equal('default')
+        expect(foundQueue).to.be.equal(defaultPirority)
+      })
+    })
+
+    describe('when processing an item from lowest priority queue', () => {
+      let foundItem
+      let foundQueue
+
+      before(async () => {
+        myQueues = new PrioritiesQueues({
+          sqs,
+          queues: {
+            [lowPirority]: `${yopaEndpoint}/${lowPirority}`,
+            [defaultPirority]: `${yopaEndpoint}/${defaultPirority}`,
+            [highPirority]: `${yopaEndpoint}/${highPirority}`,
+          },
+          priorities: [
+            highPirority,
+            defaultPirority,
+            lowPirority,
+          ],
+          concurrency: 1,
+        })
+
+        await myQueues.push('low', lowPirority)
+      })
+
+      before(async () => {
+        await myQueues.startProcessing(
+          (body, { queue }) => {
+            foundItem = body
+            foundQueue = queue
+          },
+          {
+            oneShot: true,
+          }
+        )
+      })
+
+      it('should have an item processed from the low priority queue', () => {
+        expect(foundItem).to.be.equal('low')
+        expect(foundQueue).to.be.equal(lowPirority)
+      })
+    })
+
+    describe('when processing three items from distinct queues', () => {
+      const foundItems = []
+      const foundQueues = []
+
+      before(async () => {
+        myQueues = new PrioritiesQueues({
+          sqs,
+          queues: {
+            [lowPirority]: `${yopaEndpoint}/${lowPirority}`,
+            [defaultPirority]: `${yopaEndpoint}/${defaultPirority}`,
+            [highPirority]: `${yopaEndpoint}/${highPirority}`,
+          },
+          priorities: [
+            highPirority,
+            defaultPirority,
+            lowPirority,
+          ],
+          concurrency: 1,
+        })
+
+        await myQueues.push('high', highPirority)
+        await myQueues.push('default', defaultPirority)
+        await myQueues.push('low', lowPirority)
+      })
+
+      before(async () => {
+        await myQueues.startProcessing(
+          (body, { queue }) => {
+            foundItems.push(body)
+            foundQueues.push(queue)
+          },
+          {
+            oneShot: true,
+          }
+        )
+
+        await myQueues.startProcessing(
+          (body, { queue }) => {
+            foundItems.push(body)
+            foundQueues.push(queue)
+          },
+          {
+            oneShot: true,
+          }
+        )
+
+        await myQueues.startProcessing(
+          (body, { queue }) => {
+            foundItems.push(body)
+            foundQueues.push(queue)
+          },
+          {
+            oneShot: true,
+          }
+        )
+      })
+
+      it('should have the first item processed from the high priority queue', () => {
+        expect(foundItems[0]).to.be.equal('high')
+        expect(foundQueues[0]).to.be.equal(highPirority)
+      })
+
+      it('should have the second item processed from the default priority queue', () => {
+        expect(foundItems[1]).to.be.equal('default')
+        expect(foundQueues[1]).to.be.equal(defaultPirority)
+      })
+
+      it('should have the third item processed from the low priority queue', () => {
+        expect(foundItems[2]).to.be.equal('low')
+        expect(foundQueues[2]).to.be.equal(lowPirority)
+      })
+    })
+
+    describe('when processing items from distinct queues using maxPriorityRetries', () => {
+      const foundItems = []
+      const foundQueues = []
+
+      before(async () => {
+        myQueues = new PrioritiesQueues({
+          sqs,
+          queues: {
+            [lowPirority]: `${yopaEndpoint}/${lowPirority}`,
+            [defaultPirority]: `${yopaEndpoint}/${defaultPirority}`,
+            [highPirority]: `${yopaEndpoint}/${highPirority}`,
+          },
+          priorities: [
+            highPirority,
+            defaultPirority,
+            lowPirority,
+          ],
+          concurrency: 1,
+          maxPriorityRetries: 2,
+        })
+
+        await myQueues.push('high-1', highPirority)
+        await myQueues.push('high-2', highPirority)
+        await myQueues.push('high-3', highPirority)
+        await myQueues.push('default-1', defaultPirority)
+      })
+
+      before(async () => {
+        await myQueues.startProcessing(
+          (body, { queue }) => {
+            foundItems.push(body)
+            foundQueues.push(queue)
+          },
+          {
+            oneShot: true,
+          }
+        )
+
+        await myQueues.startProcessing(
+          (body, { queue }) => {
+            foundItems.push(body)
+            foundQueues.push(queue)
+          },
+          {
+            oneShot: true,
+          }
+        )
+
+        await myQueues.startProcessing(
+          (body, { queue }) => {
+            foundItems.push(body)
+            foundQueues.push(queue)
+          },
+          {
+            oneShot: true,
+          }
+        )
+
+        await myQueues.startProcessing(
+          (body, { queue }) => {
+            foundItems.push(body)
+            foundQueues.push(queue)
+          },
+          {
+            oneShot: true,
+          }
+        )
+      })
+
+      it('should have the first item processed from the high priority queue', () => {
+        expect(foundItems[0]).to.be.equal('high-1')
+        expect(foundQueues[0]).to.be.equal(highPirority)
+      })
+
+      it('should have the second item processed from the high priority queue', () => {
+        expect(foundItems[1]).to.be.equal('high-2')
+        expect(foundQueues[1]).to.be.equal(highPirority)
+      })
+
+      it('should have the third item processed from the default priority queue', () => {
+        expect(foundItems[2]).to.be.equal('default-1')
+        expect(foundQueues[2]).to.be.equal(defaultPirority)
+      })
+
+      it('should have the forth item processed from the high priority queue', () => {
+        expect(foundItems[3]).to.be.equal('high-3')
+        expect(foundQueues[3]).to.be.equal(highPirority)
+      })
+    })
+  })
+})

--- a/yopa_config.yml
+++ b/yopa_config.yml
@@ -8,3 +8,6 @@ sqs:
 
 messaging:
   - sqs://test
+  - sqs://low-priority
+  - sqs://default-priority
+  - sqs://high-priority


### PR DESCRIPTION
# Description

This PR aims to create a new format of queues at `sqs-quooler` called `priority-queues`.

This queue handler aims to solve a problem of delivering messages to multiple queues based at a priority list given by the user, taking care also of eventually re-ordering the priorities to avoid starvation because of ultra busy queues.

How it works:
1. Instantiate the queue passing available queues and it's URLs and an array of queue names that represents the priority.
```js
const myQueues = new PrioritiesQueues({
  sqs,
  queues: {
    'low-priority-events': 'your aws endpoint + queue name',
    'default-priority-events': 'your aws endpoint + queue name',
    'high-priority-events': 'your aws endpoint + queue name',
  },
  priorities: [ // order which the startProcessing will consume items
    'high-priority-events',
    'default-priority-events',
    'low-priority-events',
  ],
  concurrency: 1,
  maxPriorityRetries: 100, // number which will temporarily reorder the priorities
})
```

2. Add items to the queues, this can be done by calling `push`
```js
myQueues.push(
  {
    data: 'test',
  },
  'high-priority-events'
)
```

3. Start processing the items from the queues
```js
myQueues.startProcessing((body, message) => {
  body: {
    data: 'test',
  }

  message: {
    Body: '{"data":"test"}',
    ReceiptHandle: 'receipt handle',
    queue: 'high-priority-events',
    ...
  }
})
```

As described previously, the main goal of this queue is to process items using a given priority list which has the following logic:

1. By default the poll items will try to get items from the 1st queue of the priority list, if there's no message, go forward to the 2nd queue and so it goes..

2. There's a counter within the `PriorityQueues` instance that will count when a queue whenever a queue has been used. This counter prevents queue starvation blocking other queues from eventually processing items if the highest priority queue is always busy.

Example:
```js
 priorities: [
    'high-priority-events',
    'default-priority-events',
    'low-priority-events',
 ],
 maxPriorityRetries: 3,
```

Imagine that we have 5 items in each queue, the order of queues being consumed will be:
`1, 1, 1, 2, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 3`

If the `maxPriorityRetries` were set to 100 for example the result would be:
`1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3`

The scenario without a maxPriorityRetries seems always correct but in some cases this can lead to a starvation scenario where other queues will never have its items consumed.

**Please, feel free to make questions and suggestions regarding its main idea as well!** 😬 