### PR TITLE
Fix memory leak

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -133,7 +133,12 @@ var Queue = function (_EventEmitter) {
       self.running = true;
 
       var processItem = function processItem(message) {
-        var body = JSON.parse(message.Body);
+        var body = '';
+        try {
+          body = JSON.parse(message.Body);
+        } catch (e) {
+          body = message.Body;
+        }
 
         var deleteMessage = function deleteMessage() {
           if (options.keepMessages) {
@@ -173,11 +178,17 @@ var Queue = function (_EventEmitter) {
         }
 
         var runAgain = function runAgain(items) {
-          if (items.length < self.options.concurrency && options.oneShot) {
-            return _bluebird2.default.resolve();
+          if (options.oneShot) {
+            if (items.length < self.options.concurrency) {
+              return _bluebird2.default.resolve();
+            }
+
+            return pollItems();
           }
 
-          return pollItems();
+          // Async call without return to avoid memory leak
+          pollItems();
+          return _bluebird2.default.resolve();
         };
 
         var handleCriticalError = function handleCriticalError(err) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqs-quooler",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "An abstraction of AWS SQS",
   "license": "MIT",
   "repository": {

--- a/src/queue.js
+++ b/src/queue.js
@@ -89,11 +89,17 @@ export default class Queue extends EventEmitter {
       }
 
       const runAgain = (items) => {
-        if (items.length < self.options.concurrency && options.oneShot) {
-          return Bluebird.resolve()
+        if (options.oneShot) {
+          if (items.length < self.options.concurrency) {
+            return Bluebird.resolve()
+          }
+
+          return pollItems()
         }
 
-        return pollItems()
+        // Async call without return to avoid memory leak
+        pollItems()
+        return Bluebird.resolve()
       }
 
       const handleCriticalError = (err) => {

--- a/test/queue-spec.js
+++ b/test/queue-spec.js
@@ -109,7 +109,6 @@ describe('Queue', () => {
   })
 
   describe('when processing items', () => {
-    let startPromise
     const items = []
     let queue
 
@@ -125,17 +124,13 @@ describe('Queue', () => {
     })
 
     before((done) => {
-      const result = queue.startProcessing((item) => {
+      queue.startProcessing((item) => {
         items.push(item)
 
         if (items.length >= 2) {
           done()
         }
       })
-
-      // This should only be assumed here, as we now that we use bluebird
-      // And we only use this in order to inspect the promise state
-      startPromise = result
     })
 
     it('process the items in the queue', () => {
@@ -143,14 +138,14 @@ describe('Queue', () => {
     })
 
     it('should not resolve promise returned in startProcessing', () => {
-      expect(startPromise.isPending()).to.equal(true)
+      expect(queue.running).to.equal(true)
     })
 
     describe('when stopping the queue', () => {
       before(() => queue.stopProcessing())
 
       it('should resolve promise returned in startProcessing', () => {
-        expect(startPromise.isPending()).to.equal(false)
+        expect(queue.running).to.equal(false)
       })
 
       it('should stop consuming the queue', async () => {


### PR DESCRIPTION
# Description

After a lot of investigation it seems that a possible cause for the memory leak to happen is due the fact that at the end of every `pollItems` call we call the `runAgain` function returning a Promise and by that we restart the recurrent `pollItems` execution.

By returning this function call we lock the used resources from being released by the garbage collector.
Because of this behavior for every iteration we always hold a couple variables waiting for the called function to return and resume its execution but due the nature of the `pollItems` that never happen.

This is an attempt (I've tested locally and it seemed to worked fine) to solve this issue.