### PR TITLE
Add attribute names parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,11 @@ myQueue.changeMessageVisibility({
 >`myQueue.startProcessing` (handler: function, options: object) : Promise
 
 Handler function should accept 2 arguments, the first one being the parsed message `Body` value, and the second one being the whole message object. It will be called once for every message found in the queue (depending on the queue's `concurrency`).
-The options object is optional and may receive a `keepMessages` property (boolean).
+
+The options object is optional and accept the following properties:
+- `keepMessages` (boolean): To avoid deleting the message after processing it. Default is `false`.
+- `messageAttributesNames` (string array): The value which will be sent to the `receiveMessage` SQS method at the `MessageAttributeNames` property. Default value is `['ALL']`.
+
 After the handler returns (if it returns a Promise, SQS Quooler will wait for it to resolve), the item is automatically deleted from the queue. If your handler throws an error, or returns a rejected Promise, the item will not be removed from the queue.
 
 ```javascript
@@ -85,6 +89,14 @@ myQueue.startProcessing((body, message) => {
   // message: {
   //   Body: '{"data":"test"}',
   //   ReceiptHandle: 'receipt handle',
+  //   MessageAttributes: {
+  //     custom_attribute: {
+  //       StringValue: 'custom_attribute value',
+  //       StringListValues: [],
+  //       BinaryListValues: [],
+  //       DataType: 'String'
+  //     }
+  //   }
   //   ...
   // }
 })

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -199,7 +199,8 @@ var Queue = function (_EventEmitter) {
 
         return _bluebird2.default.resolve(self.options.sqs.receiveMessage({
           QueueUrl: self.options.endpoint,
-          MaxNumberOfMessages: self.options.concurrency
+          MaxNumberOfMessages: self.options.concurrency,
+          MessageAttributeNames: options.messageAttributeNames || ['ALL']
         }).promise()).get('Messages').then(coerce).map(processItem).tap(delay).then(runAgain).catch(handleCriticalError);
       };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sqs-quooler",
-  "version": "1.5.1",
+  "version": "1.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1670,7 +1670,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1691,12 +1692,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1711,17 +1714,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1838,7 +1844,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1850,6 +1857,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1864,6 +1872,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1871,12 +1880,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1895,6 +1906,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1975,7 +1987,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1987,6 +2000,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2072,7 +2086,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2108,6 +2123,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2127,6 +2143,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2170,12 +2187,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -2221,6 +2240,7 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-glob": "^2.0.0"
       }
@@ -2461,7 +2481,8 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -2512,7 +2533,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
       "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-finite": {
       "version": "1.0.2",
@@ -2534,6 +2556,7 @@
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-extglob": "^1.0.0"
       }
@@ -2684,6 +2707,7 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-buffer": "^1.1.5"
       }
@@ -2893,6 +2917,7 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
+      "optional": true,
       "requires": {
         "remove-trailing-separator": "^1.0.1"
       }
@@ -3321,13 +3346,15 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "repeat-element": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
       "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "repeat-string": {
       "version": "1.6.1",
@@ -3411,7 +3438,8 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "safer-buffer": {
       "version": "2.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sqs-quooler",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqs-quooler",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "An abstraction of AWS SQS",
   "license": "MIT",
   "repository": {

--- a/src/queue.js
+++ b/src/queue.js
@@ -112,6 +112,7 @@ export default class Queue extends EventEmitter {
         .receiveMessage({
           QueueUrl: self.options.endpoint,
           MaxNumberOfMessages: self.options.concurrency,
+          MessageAttributeNames: options.messageAttributeNames || ['ALL'],
         })
         .promise())
         .get('Messages')

--- a/test/queue-spec.js
+++ b/test/queue-spec.js
@@ -110,6 +110,7 @@ describe('Queue', () => {
 
   describe('when processing items', () => {
     const items = []
+    const messages = []
     let queue
 
     before(async () => {
@@ -119,13 +120,28 @@ describe('Queue', () => {
         concurrency: 1,
       })
 
-      await queue.push('gretchen')
-      await queue.push('actress')
+      await queue.push('gretchen', {
+        MessageAttributes: {
+          type: {
+            DataType: 'String',
+            StringValue: 'name',
+          },
+        },
+      })
+      await queue.push('actress', {
+        MessageAttributes: {
+          type: {
+            DataType: 'String',
+            StringValue: 'adjective',
+          },
+        },
+      })
     })
 
     before((done) => {
-      queue.startProcessing((item) => {
+      queue.startProcessing((item, message) => {
         items.push(item)
+        messages.push(message)
 
         if (items.length >= 2) {
           done()
@@ -135,6 +151,27 @@ describe('Queue', () => {
 
     it('process the items in the queue', () => {
       expect(items).to.containSubset(['gretchen', 'actress'])
+    })
+
+    it('should have the correct messages', () => {
+      expect(messages).to.have.lengthOf(2)
+
+      expect(messages[0].MessageAttributes).to.deep.equal({
+        type: {
+          DataType: 'String',
+          StringValue: 'name',
+          BinaryListValues: [],
+          StringListValues: [],
+        },
+      })
+      expect(messages[1].MessageAttributes).to.deep.equal({
+        type: {
+          DataType: 'String',
+          StringValue: 'adjective',
+          BinaryListValues: [],
+          StringListValues: [],
+        },
+      })
     })
 
     it('should not resolve promise returned in startProcessing', () => {


### PR DESCRIPTION
Quando usamos o método `startProcessing`, não recebemos os `MessageAttributeNames` vindo do SQS, este PR altera o método `startProcessing` para suportar receber o valor da propriedade por parâmetro. O valor padrão da propriedade, quando não enviada, é `['ALL']` que faz com que sejam retornados todos os atributos da mensagem.