### PR TITLE
Add purge method

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,15 @@ myQueue.startProcessing((body, message) => {
 myQueue.stopProcessing()
 ```
 
+### Purge the queue
+>`myQueue.purge` () : Promise
+
+Deletes all messages in a queue
+
+```javascript
+myQueue.purge()
+```
+
 ## License
 >You can check out the full license [here](https://github.com/pagarme/sqs-quooler/blob/master/LICENSE)
 

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -218,6 +218,33 @@ var Queue = function (_EventEmitter) {
 
       return this.stopped.promise;
     }
+  }, {
+    key: 'purge',
+    value: function () {
+      var _ref4 = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee4() {
+        return regeneratorRuntime.wrap(function _callee4$(_context4) {
+          while (1) {
+            switch (_context4.prev = _context4.next) {
+              case 0:
+                _context4.next = 2;
+                return this.options.sqs.purgeQueue({
+                  QueueUrl: this.options.endpoint
+                }).promise();
+
+              case 2:
+              case 'end':
+                return _context4.stop();
+            }
+          }
+        }, _callee4, this);
+      }));
+
+      function purge() {
+        return _ref4.apply(this, arguments);
+      }
+
+      return purge;
+    }()
   }]);
 
   return Queue;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqs-quooler",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "description": "An abstraction of AWS SQS",
   "license": "MIT",
   "repository": {

--- a/src/queue.js
+++ b/src/queue.js
@@ -136,4 +136,11 @@ export default class Queue extends EventEmitter {
 
     return this.stopped.promise
   }
+
+  async purge () {
+    await this.options.sqs
+      .purgeQueue({
+        QueueUrl: this.options.endpoint,
+      }).promise()
+  }
 }

--- a/test/queue-spec.js
+++ b/test/queue-spec.js
@@ -362,4 +362,34 @@ describe('Queue', () => {
       expect(items[1]).to.be.equal(invalidJSON)
     })
   })
+
+  describe('when purging a queue', () => {
+    let queue
+    let receiveMessageResponse
+
+    before(async () => {
+      queue = new Queue({
+        sqs,
+        endpoint: TestEndpoint,
+        concurrency: 1,
+      })
+
+      await Promise.all([
+        queue.push('Hey'),
+        queue.push('Ho'),
+        queue.push('Let`s go'),
+      ])
+
+      await queue.purge()
+
+      receiveMessageResponse = await sqs.receiveMessage({
+        QueueUrl: TestEndpoint,
+        MaxNumberOfMessages: 1,
+      }).promise()
+    })
+
+    it('should have no items in the queue', () => {
+      expect(receiveMessageResponse).to.not.have.property('Messages')
+    })
+  })
 })


### PR DESCRIPTION
# Description

This PR adds a feature to purge a queue.

By doing so, it makes easier to develop tests on applications that use `sqs-quooler` because it will no longer be needed to create a `helper function` that clears a queue.