### PR TITLE
queue: add AttributeNames option to receiveMessage

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Handler function should accept 2 arguments, the first one being the parsed messa
 The options object is optional and accept the following properties:
 - `keepMessages` (boolean): To avoid deleting the message after processing it. Default is `false`.
 - `messageAttributesNames` (string array): The value which will be sent to the `receiveMessage` SQS method at the `MessageAttributeNames` property. Default value is `['All']`.
+- `attributeNames` (string array): A list of attributes that need to be returned along with each message, within the `Attributes` property. Default value is `['All']`.
 
 After the handler returns (if it returns a Promise, SQS Quooler will wait for it to resolve), the item is automatically deleted from the queue. If your handler throws an error, or returns a rejected Promise, the item will not be removed from the queue.
 

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -200,7 +200,8 @@ var Queue = function (_EventEmitter) {
         return _bluebird2.default.resolve(self.options.sqs.receiveMessage({
           QueueUrl: self.options.endpoint,
           MaxNumberOfMessages: self.options.concurrency,
-          MessageAttributeNames: options.messageAttributeNames || ['All']
+          MessageAttributeNames: options.messageAttributeNames || ['All'],
+          AttributeNames: options.attributeNames || ['All']
         }).promise()).get('Messages').then(coerce).map(processItem).tap(delay).then(runAgain).catch(handleCriticalError);
       };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqs-quooler",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "An abstraction of AWS SQS",
   "license": "MIT",
   "repository": {

--- a/src/queue.js
+++ b/src/queue.js
@@ -113,6 +113,7 @@ export default class Queue extends EventEmitter {
           QueueUrl: self.options.endpoint,
           MaxNumberOfMessages: self.options.concurrency,
           MessageAttributeNames: options.messageAttributeNames || ['All'],
+          AttributeNames: options.attributeNames || ['All'],
         })
         .promise())
         .get('Messages')

--- a/test/queue-spec.js
+++ b/test/queue-spec.js
@@ -164,6 +164,7 @@ describe('Queue', () => {
           StringListValues: [],
         },
       })
+
       expect(messages[1].MessageAttributes).to.deep.equal({
         type: {
           DataType: 'String',
@@ -172,6 +173,17 @@ describe('Queue', () => {
           StringListValues: [],
         },
       })
+
+      expect(messages[0].Attributes).to.have.property('SentTimestamp')
+      expect(messages[0].Attributes).to.have.property('ApproximateReceiveCount', '1')
+      expect(messages[0].Attributes).to.have.property('ApproximateFirstReceiveTimestamp')
+      expect(messages[0].Attributes).to.have.property('SenderId')
+
+
+      expect(messages[1].Attributes).to.have.property('SentTimestamp')
+      expect(messages[1].Attributes).to.have.property('ApproximateReceiveCount', '1')
+      expect(messages[1].Attributes).to.have.property('ApproximateFirstReceiveTimestamp')
+      expect(messages[1].Attributes).to.have.property('SenderId')
     })
 
     it('should not resolve promise returned in startProcessing', () => {


### PR DESCRIPTION
## Description

This PR adds a new option parameter to the `receiveMessage` call, within `startProcessing` method, named **AttributeNames**, which returns an object containing metadata attributes for each message.  Those attributes include a particularly interesting field called "**ApproximateReceiveCount**" that returns the number of times a message has been received across multiple workers but not deleted. That information is useful to know if a particular message has been retried a couple of times and also it allows applications to handle the max number of retries for a specific message type. 

More info can be found at [AWS SDK docs](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/SQS.html)
